### PR TITLE
Rename app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Blending
+# Kompismatchning
 
-Blending is a tool that helps organizations, cities and municipalities pair immigrants and refugees with people from the local community. It is currently being used by [IM](https://www.manniskohjalp.se) to run the Duo Stockholm program. It is free to use for anyone who wants to set up a similar program.
+Kompismatchning is a tool that helps organizations, cities and municipalities pair immigrants and refugees with people from the local community. It is currently being used by [IM](https://www.manniskohjalp.se) to run the Duo Stockholm program. It is free to use for anyone who wants to set up a similar program.
 
-A demo is available at https://blending.herokuapp.com/admin. Login with `admin@example.com` and `password`.
+A demo is available at https://kompismatchning.herokuapp.com/admin. Login with `admin@example.com` and `password`.
 
 ## Requirements
 
-Blending is built with Ruby on Rails and requires a server running Ruby and an SQL database such as Postgres. An e-mail service such as [SendGrid](https://www.sendgrid.com) is required to send e-mails. We recommend installing and running the application on the [Heroku](https://www.heroku.com) platform.
+Kompismatchning is built with Ruby on Rails and requires a server running Ruby and an SQL database such as Postgres. An e-mail service such as [SendGrid](https://www.sendgrid.com) is required to send e-mails. We recommend installing and running the application on the [Heroku](https://www.heroku.com) platform.
 
 ## Running the application locally
 

--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
-  "name": "blending",
+  "name": "kompismatchning",
   "scripts": {
     "postdeploy": "bin/setup"
   },

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,7 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module Blending
+module Kompismatchning
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,8 +5,8 @@ default: &default
 
 development:
   <<: *default
-  database: blending_development
+  database: kompismatchning_development
 
 test:
   <<: *default
-  database: blending_test
+  database: kompismatchning_test

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,7 +54,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "blending_#{Rails.env}"
+  # config.active_job.queue_name_prefix = "kompismatchning_#{Rails.env}"
   config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_blending_session'
+Rails.application.config.session_store :cookie_store, key: '_kompismatchning_session'


### PR DESCRIPTION
This PR renames the app from `blending` to `kompismatchning`.