### PR TITLE
Remove concluded matches and their people

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Heroku Scheduler needs to be configured to run some tasks at regular intervals. 
 $ heroku addons:open scheduler
 ```
 
-Configure the scheduler to run `rails matches:mails` daily at the time you want match participants to receive their follow up and conclusion mails.
+Configure the scheduler to run `rails matches:mails` daily at the time you want match participants to receive their follow up and conclusion mails. Also configure it to run `rails matches:destroy_concluded` daily to destroy matches (and people) at a configurable time after conclusion.
 
 ### Configure SendGrid
 
@@ -77,4 +77,7 @@ config.follow_up_matches_after = 1.month
 
 # The time after which to automatically conclude matches.
 config.conclude_matches_after = 6.months
+
+# The time after which to automatically destroy concluded matches and people.
+config.destroy_matches_and_people_after = 2.months
 ```

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -28,6 +28,10 @@ class Match < ApplicationRecord
              .where(send_conclusion_mail: true)
   })
 
+  scope :concluded_to_destroy, (lambda {
+    concluded.where("concluded_at < ?", Rails.configuration.destroy_matches_and_people_after.ago)
+  })
+
   def matched_with(person)
     newcomer == person ? established : newcomer
   end
@@ -81,6 +85,12 @@ class Match < ApplicationRecord
     return 0 unless concluded_at.present? && started_at.present?
 
     100 * ((Time.zone.now - started_at) / (concluded_at - started_at))
+  end
+
+  def destroy_with_people
+    newcomer.destroy
+    established.destroy
+    destroy
   end
 
   def to_s

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,5 +27,8 @@ module Kompismatchning
 
     # The time after which to automatically conclude matches.
     config.conclude_matches_after = 6.months
+
+    # The time after which to automatically destroy concluded matches and people.
+    config.destroy_matches_and_people_after = 2.months
   end
 end

--- a/lib/tasks/matches.rake
+++ b/lib/tasks/matches.rake
@@ -30,4 +30,13 @@ namespace :matches do
       match.save
     end
   end
+
+  desc "Destroy concluded matches and people"
+  task destroy_concluded: :environment do
+    matches_to_process = Match.concluded_to_destroy
+
+    puts "Destroying #{matches_to_process.count} matches and their people"
+
+    matches_to_process.each(&:destroy_with_people)
+  end
 end

--- a/test/models/match_test.rb
+++ b/test/models/match_test.rb
@@ -100,4 +100,36 @@ class MatchTest < ActiveSupport::TestCase
 
     assert_not Match.follow_up_mails.include?(match)
   end
+
+  def test_destroy_concluded_to_destroy_scope_included
+    match = create_match(
+      newcomer: create_person(status: :newcomer),
+      established: create_person(status: :established),
+      started_at: 2.months.ago,
+      concluded_at: 2.months.ago
+    )
+
+    assert Match.concluded_to_destroy.include?(match)
+  end
+
+  def test_destroy_concluded_to_destroy_scope_not_included
+    match = create_match(
+      newcomer: create_person(status: :newcomer),
+      established: create_person(status: :established),
+      started_at: 1.month.ago,
+      concluded_at: 1.week.ago
+    )
+
+    assert_not Match.concluded_to_destroy.include?(match)
+  end
+
+  def test_destroy_with_people
+    person_1 = create_person(status: :newcomer)
+    person_2 = create_person(status: :established)
+    match = create_match(newcomer: person_1, established: person_2)
+    match.destroy_with_people
+    assert person_1.destroyed?
+    assert person_2.destroyed?
+    assert match.destroyed?
+  end
 end


### PR DESCRIPTION
This PR adds functionality so that concluded matches are automatically destroyed 2 months after the conclusion date. This will also remove the people associated with the match.

It has to be configured with the Heroku scheduler.